### PR TITLE
修复 Star 历史图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ console.log("完成");
 #### 程序原理
 ![run_lc.svg](run_lc.svg)
 
-[![Star History](https://api.star-history.com/svg?repos=bszapp/android-wifi-pojie&type=Date)](https://star-history.com/#bszapp/android-wifi-pojie&Date)
+[![Star History](https://star-history.dera.page/svg?repos=bszapp/android-wifi-pojie&type=Date)](https://star-history.dera.page/#bszapp/android-wifi-pojie&Date)


### PR DESCRIPTION
当前 README 中的 Star 历史图表已经失效，无法正常展示项目的星标趋势。本 PR 将图表切换到新的数据源（star-history.dera.page），该数据源无需 API token 即可工作。修复后星标趋势图将恢复正常显示，欢迎查看。